### PR TITLE
fix multiline outputs

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ try {
     const replaceAllInput = core.getInput('replaceAll')
     const replaceAll = replaceAllInput ? replaceAllInput == 'true' : false
     const resultValue = replaceAll ? source.replaceAll(find, replace) : source.replace(find, replace)
-    fs.writeFileSync(process.env.GITHUB_OUTPUT, `value=${resultValue}\n`)
+    core.setOutput('value', resultValue)
 } catch (error) {
     core.setFailed(error.message)
 }


### PR DESCRIPTION
This PR reverts a small change introduced with 84f77c461194e7470d3cce8adba0f4aea3f0ff35 where setting the action's output has been changed from using `@actions/core`'s `setOutput` function to writing the output to `process.env.GITHUB_OUTPUT`:
https://github.com/mad9000/actions-find-and-replace-string/blob/84f77c461194e7470d3cce8adba0f4aea3f0ff35/index.js#L11

This is exactly how it's described in GitHub's blog announcing the deprecation: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

However, this does not work for multiline outputs, as they now fail with an error similar to this:
```
...
Run mad9000/actions-find-and-replace-string@3
##[debug]Node Action run completed with exit code 0
##[debug]Set output value = <first-output-line>
Error: Unable to process file command 'output' successfully.
Error: Invalid format '<second-output-line>'
##[debug]System.Exception: Invalid format '<second-output-line>'
##[debug]   at GitHub.Runner.Worker.EnvFileKeyValuePairs.GetEnumerator()+MoveNext()
##[debug]   at GitHub.Runner.Worker.SetOutputFileCommand.ProcessCommand(IExecutionContext context, String filePath, ContainerInfo container)
##[debug]   at GitHub.Runner.Worker.FileCommandManager.ProcessFiles(IExecutionContext context, ContainerInfo container)
##[debug]Finishing: <workflow-step-name>
...
```

In fact, the `@action/core` library provided by GitHub has been updated a few days before the deprecation was announced such that `setOutput` uses the new file-based mechanism (and correctly handles multi-line outputs by using an EOF-delimiter based approach): https://github.com/actions/toolkit/pull/1178
This change is contained in `@action/core==1.10.0`, which is already being used by this action.

Long story short: This PR reverts this change to use `setOutput` provided by `@actions/core` again, which should fix issues with multi-line outputs.